### PR TITLE
Expand the acronym and comment out optional section

### DIFF
--- a/templates/CODE_OF_CONDUCT.MD
+++ b/templates/CODE_OF_CONDUCT.MD
@@ -1,14 +1,15 @@
 # Community Participation Guidelines
 
 This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
-For more details, please read
+For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
 
 ## How to Report
-For more information on how to report violations of the CPG, please read our '[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)' page.
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)' page.
 
-
+<!--
 ## Project Specific Etiquette
 
 In some cases, there will be additional project etiquette i.e.: (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
 Please update for your project.
+-->


### PR DESCRIPTION
This
* adds the word `the` to make the second sentence a complete sentence
* expands the acronym CPG as in a document this short, it doesn't save the reader much using the acronym and has potential to confuse
* comments out the optional project specific section so it's clear to someone using this template that they don't need to fill that section out and if they were to, they would uncomment it