### PR TITLE
Technical Fixes

### DIFF
--- a/templates/CODE_OF_CONDUCT.md
+++ b/templates/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@ For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
 
 ## How to Report
-For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)' page.
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
 
 <!--
 ## Project Specific Etiquette


### PR DESCRIPTION
1. Renamed to lower case the extension, to follow GitHub's guidelines.
2. Removed the specific 'en-US' locale from the Report URL. Mozilla.org
   will serve the user's preferred locale.