### PR TITLE
Fix whitespace (linting)

### DIFF
--- a/templates/CODE_OF_CONDUCT.md
+++ b/templates/CODE_OF_CONDUCT.md
@@ -1,10 +1,11 @@
 # Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
 For more details, please read the
-[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
+
 For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.
 
 <!--


### PR DESCRIPTION
Remove end-of-line spaces and add a newline after the heading, to make [markdownlint](https://dlaa.me/markdownlint/) happy.

Replaces PR #3 , fixes issue #6.